### PR TITLE
change tinyint datatype to integer

### DIFF
--- a/lib/migrations/guard-schema.js
+++ b/lib/migrations/guard-schema.js
@@ -73,7 +73,7 @@ let schemas = {
             allowNull: false,
         },
         allow : {
-            type : DataTypes.TINYINT,
+            type : DataTypes.INTEGER,
             allowNull : true,
             defaultValue : 1
         }


### PR DESCRIPTION
due to SequelizeDatabaseError: type "tinyint" does not exist exception